### PR TITLE
IDMEIAM-113: Add user flow

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,7 +25,9 @@ export default function Router() {
 
             return composeComponents(
                 [Route, { key: `route-${key}`, path, exact: true }],
-                redirectTo ? [Redirect, { to: redirectTo }] : (descriptor && [DescriptorLoader, { descriptor, genericInfo }])
+                redirectTo ? [Redirect, { to: redirectTo }] : (
+                    descriptor && [DescriptorLoader, { descriptor, genericInfo, key: descriptor }]
+                )
             )(<Screen info={genericInfo} Layout={Layout} subScreens={subScreens} />);
         })
     );

--- a/src/screens/dashboard/index.js
+++ b/src/screens/dashboard/index.js
@@ -26,7 +26,7 @@ const RightCol = ({ subScreens = {} }) => {
         const SubScreen = SubScreens[component];
 
         return SubScreen && composeComponents(
-            descriptor && [DescriptorLoader, { descriptor }]
+            descriptor && [DescriptorLoader, { descriptor, key: descriptor }]
         )(<SubScreen />) || null;
     }
 


### PR DESCRIPTION
key is required to re-render DescriptorLoader so that while transitioning between screens, components are served with fresh data